### PR TITLE
Use custom event kinds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 localhost.crt
 localhost.key
 .idea
+.vscode
 nostr

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,9 +31,12 @@ services:
     networks:
       nostr:
     environment:
-      - NOSTR_RELAYS=ws://nostr-relay:8080
+      - NOSTR_RELAYS=ws://nostr-relay:7777
       - NOSTR_PRIVATE_KEY=
       - BACKEND_HOST=mint:3338
+    depends_on:
+      - mint
+      - nostr
   exit-https:
     build:
       context: .
@@ -43,9 +46,12 @@ services:
     networks:
       nostr:
     environment:
-      - NOSTR_RELAYS=ws://nostr-relay:8080
+      - NOSTR_RELAYS=ws://nostr-relay:7777
       - NOSTR_PRIVATE_KEY=
       - BACKEND_HOST=:4443
+    depends_on:
+      - mint
+      - nostr
   entry:
     build:
       context: .
@@ -56,16 +62,17 @@ services:
     networks:
       nostr:
     environment:
-      - NOSTR_RELAYS=ws://nostr-relay:8080
+      - NOSTR_RELAYS=ws://nostr-relay:7777
+    depends_on:
+      - nostr
   nostr:
-    image: scsibug/nostr-rs-relay:latest
+    image: carroarmato0/strfry:latest
     container_name: nostr-relay
     ports:
-      - 8080:8080
+      - 7777:7777
     networks:
       nostr:
     restart: always
     volumes:
-      - ./nostr/data:/usr/src/app/db:Z
-      - ./nostr/config/config.toml:/usr/src/app/config.toml:ro,Z
-    user: 100:100
+      - ./nostr/data:/app/strfry-db/:Z
+      - ./nostr/config/strfry.conf:/app/strfry.conf:ro,Z

--- a/exit/exit.go
+++ b/exit/exit.go
@@ -61,15 +61,10 @@ func NewExit(ctx context.Context, exitNodeConfig *config.ExitConfig) *Exit {
 		// generate new private key
 		exitNodeConfig.NostrPrivateKey = nostr.GeneratePrivateKey()
 		slog.Warn(generateKeyMessage, "key", exitNodeConfig.NostrPrivateKey)
-	} else {
-		pubKey, err := nostr.GetPublicKey(exitNodeConfig.NostrPrivateKey)
-		if err != nil {
-			panic(err)
-		}
-		slog.Info("using public key", "key", pubKey)
 	}
 	// get public key from private key
 	pubKey, err := nostr.GetPublicKey(exitNodeConfig.NostrPrivateKey)
+	slog.Info("using public key", "key", pubKey)
 	if err != nil {
 		panic(err)
 	}

--- a/exit/nostr.go
+++ b/exit/nostr.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/asmogo/nws/protocol"
 	"github.com/nbd-wtf/go-nostr"
 )
 
@@ -18,9 +19,8 @@ func (e *Exit) announceExitNode(ctx context.Context) error {
 			event := nostr.Event{
 				PubKey:    e.publicKey,
 				CreatedAt: nostr.Now(),
-				Kind:      nostr.KindTextNote,
+				Kind:      protocol.KindAnnouncementEvent,
 				Tags: nostr.Tags{
-					nostr.Tag{"n", "nws"},
 					nostr.Tag{"expiration", strconv.FormatInt(time.Now().Add(time.Second*10).Unix(), 20)},
 				},
 			}

--- a/netstr/dns.go
+++ b/netstr/dns.go
@@ -3,10 +3,12 @@ package netstr
 import (
 	"context"
 	"fmt"
-	"github.com/nbd-wtf/go-nostr"
 	"net"
 	"strings"
 	"time"
+
+	"github.com/asmogo/nws/protocol"
+	"github.com/nbd-wtf/go-nostr"
 )
 
 // NostrDNS does not resolve anything
@@ -36,9 +38,8 @@ func (d NostrDNS) Resolve(ctx context.Context, name string) (context.Context, ne
 	}
 	since := nostr.Timestamp(time.Now().Add(-time.Second * 10).Unix())
 	ev := d.pool.QuerySingle(ctx, d.nostrRelays, nostr.Filter{
-		Kinds: []int{nostr.KindTextNote},
+		Kinds: []int{protocol.KindAnnouncementEvent},
 		Since: &since,
-		Tags:  nostr.TagMap{"n": []string{"nws"}},
 	})
 	if ev == nil {
 		return ctx, nil, fmt.Errorf("failed to find exit node event")

--- a/protocol/signer.go
+++ b/protocol/signer.go
@@ -1,13 +1,23 @@
 package protocol
 
 import (
+	"log/slog"
+
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/nbd-wtf/go-nostr/nip04"
-	"log/slog"
 )
 
 // KindEphemeralEvent represents the unique identifier for ephemeral events.
-const KindEphemeralEvent int = 38333
+const KindEphemeralEvent int = 28333
+
+// KindAnnouncementEvent represents the unique identifier for announcement events.
+const KindAnnouncementEvent int = 38333
+
+// KindCertificateEvent represents the unique identifier for certificate events.
+const KindCertificateEvent int = 38334
+
+// KindPrivateKeyEvent represents the unique identifier for private key events.
+const KindPrivateKeyEvent int = 38335
 
 // EventSigner represents a signer that can create and sign events.
 //


### PR DESCRIPTION
In preparation for a production release, unique event kinds should be used to avoid application conflicts.